### PR TITLE
Add zkTLS ecosystem projects and content

### DIFF
--- a/public/data/business-ops.md
+++ b/public/data/business-ops.md
@@ -39,6 +39,7 @@ At the same time, advances in AI create the potential for organizations that cou
 - [LexTek](https://lextek.eth.limo/) - Onchain legal automation templates
 - [Request Finance](https://www.request.finance/) - Accounts payable, accounts receivable, and accounting
 - [Smart Invoice](https://www.smartinvoice.xyz/) - Invoicing, escrow, and arbitration
+- [Loop Crypto](https://www.loopcrypto.xyz/) - Subscription billing, invoicing, and recurring payments
 
 ## Resources
 

--- a/public/data/credit-and-capital-formation.md
+++ b/public/data/credit-and-capital-formation.md
@@ -24,7 +24,7 @@ Small and medium enterprises (SMEs) are underserved by traditional finance: cred
 - [Pact](https://pactfoundation.com/) - Cooperative credit systems
 - [EthicHub](https://www.ethichub.com/) - Crowdlending to smallholder farmers
 - [Kotanipay](https://kotanipay.com/) - Microloans via mobile money rails
-- World Credit mini-app - Peer-to-peer microfinance
+- Credit mini-app on World - Leverages proof of personhood to issue microloans
 - [Haraka](https://haraka.xyz/) - Microloans and alternative credit scoring
 - [Union](https://union.finance/) - Decentralized credit protocol
 - [Topos](https://topos.one/) - Global credit network (exploratory)
@@ -43,6 +43,7 @@ Small and medium enterprises (SMEs) are underserved by traditional finance: cred
 - [Legion](https://legion.cc/) - Syndicated investment
 - [Echo](https://echo.xyz/) - Syndicated investment
 - [StationX](https://www.stationx.network/) - Syndicated investment
+- [Earnifi](https://goearnifi.com/) - Borrow against earned wages through zkTLS-verified paystubs
 
 ## Resources
 

--- a/public/data/data.md
+++ b/public/data/data.md
@@ -13,6 +13,7 @@ Data already trades through brokers, ad-tech exchanges, and bespoke deals betwee
 - Data marketplace - Platforms where data access is governed by smart contracts, enabling licensing, metering, revocation, royalties, and automatic revenue splits
 - Tokenized data assets - Data exposed as onchain assets (e.g., streams, APIs, models, analytics outputs) that can be priced, combined, and traded like financial instruments
 - Fact checking oracles - Incentivize truth discovery through cryptoeconomic incentives
+- zkTLS-verified data - Users prove claims from existing web platforms&mdash;income, identity, activity&mdash;for use in onchain applications, without requiring platform permission or surrendering raw data
 
 ## Projects
 
@@ -23,6 +24,7 @@ Data already trades through brokers, ad-tech exchanges, and bespoke deals betwee
 - [Ocean Protocol](https://oceanprotocol.com/) - Decentralized data exchange protocol
 - [Origin Trail](https://www.origintrail.io/) - Decentralized knowledge graph for reliable AI
 - [Navigate](https://nvg8.io/) - Rewards users for contributing and licensing their data
+- [Opacity Network](https://www.opacitynetwork.com/) - zkTLS infrastructure that makes existing internet data verifiable and composable with crypto without requiring institutional permission
 
 ## Resources
 

--- a/public/data/marketing-and-advertising.md
+++ b/public/data/marketing-and-advertising.md
@@ -17,7 +17,8 @@ Digital advertising is dominated by centralized platforms that control audience 
 ## Projects
 
 - [The Miracle](https://www.themiracle.io/) - Target & activate crypto users
-- [EarnOS](https://earnos.com/) - Ad platform integrating Web3 wallets and tokenized rewards
+- [DaisyPay](https://daisypay.app/) - Pays creators in stablecoins for zkTLS-verified social engagement, replacing intermediaries with direct brand-to-creator payments
+- [EarnOS](https://earnos.com/) - Privacy-preserving ad targeting where users prove actions (e.g., app usage, trading volume, fitness activity) to brands for rewards without exposing personal data
 - [MadHive](https://www.madhive.com/about-us) - Programmatic ad solutions with blockchain components
 - [EthereumAds](https://ethereumads.com/) - Lets website operators sell advertising space
 - [AdLedger](https://adledger.org/) - Blockchain consortium for advertising transparency

--- a/public/data/media-and-entertainment.md
+++ b/public/data/media-and-entertainment.md
@@ -25,7 +25,7 @@ Cultural production and distribution is bottlenecked by centralized intermediari
     - [Tokenproof](https://tokenproof.xyz/) - Token-gated ticketing and access for events
     - [Onopen](https://onopen.xyz/) - Ticketing and memberships
     - [itm.studio](https://itm.studio/) - Experiences
-    - [KYD Labs](https://kydlabs.com/) - Concert ticketing and engagement ([Article](https://x.com/KYDLabs/status/1918753011603841426))
+    - [KYD Labs](https://kydlabs.com/) - Ticketing platform where venues access USDC working capital without surrendering fan data, with a factoring protocol for investors to lend to venues and earn yield from ticket sales
 - Film
     - [Shibuya](https://www.shibuya.film/) - Film crowdfunding and participatory production
     - [Film3](https://x.com/501cfilm3) - DAO-based film projects


### PR DESCRIPTION
## Summary

- **Data**: Added Opacity Network as a project and "zkTLS-verified data" as a new idea
- **Marketing & Advertising**: Added DaisyPay, updated EarnOS description with privacy-preserving ad targeting detail
- **Credit & Capital Formation**: Added Earnifi (earned wage access via zkTLS-verified paystubs), updated World Credit mini-app description
- **Media & Entertainment**: Updated KYD Labs description with USDC working capital / factoring protocol detail
- **Business Ops**: Added Loop Crypto (subscription billing)

Source: [Opacity Network / zkTLS thread by @EulerLagrange](https://x.com/EulerLagrange/status/1949849843792298146)

## Test plan
- [ ] Verify all new project URLs resolve
- [ ] Check markdown renders correctly in each domain modal
- [ ] Confirm search picks up new entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)