### PR TITLE
Rename Projects section header to Examples

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/domain_edit.md
+++ b/.github/PULL_REQUEST_TEMPLATE/domain_edit.md
@@ -32,7 +32,7 @@ A 3-4 sentence description of the use case opportunity and problems being solved
 - Idea name - Description of the idea and what it enables.
 - Another idea - Its description goes here.
 
-## Projects
+## Examples
 
 - [Project Name](https://url.com) - Brief description of the project.
 - [Another Project](https://url.com) - What this project does.
@@ -60,7 +60,7 @@ Each idea should be a single line:
 - Idea name - Description explaining what it enables or solves.
 ```
 
-### Projects Format
+### Examples Format
 
 Each project should link to the project and include a brief description:
 ```

--- a/components/OverviewTab.tsx
+++ b/components/OverviewTab.tsx
@@ -67,11 +67,11 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ data }) => {
         )}
       </section>
 
-      {/* Projects Section - Card/Grid View */}
+      {/* Examples Section - Card/Grid View */}
       <section>
         <div className="flex items-center gap-2 mb-6">
           <FolderGit2 className="w-6 h-6" />
-          <h3 className="text-2xl font-bold font-heading">Projects</h3>
+          <h3 className="text-2xl font-bold font-heading">Examples</h3>
           <span className="text-sm text-gray-500 ml-2 font-sans">Who has worked on this</span>
         </div>
 

--- a/public/data/advocacy-and-rights.md
+++ b/public/data/advocacy-and-rights.md
@@ -17,7 +17,7 @@ Civil society groups, environmental defenders, human-rights advocates, journalis
 - Portable identity & credentials for NGOs, volunteers & journalists - Selective-disclosure credentials backed by onchain verification to manage trust while protecting privacy
 - Programmable rights & participatory governance tokens - Embedding rights-related commitments or governance frameworks into tokens or DAOs for accountability across actors
 
-## Projects
+## Examples
 
 - [Labor DAO](https://www.thelabordao.com) - Perpetual, transparent revolving fund to finance and support worker organizing, strikes, legal defense, and labor campaigns
 - [ProofLeak](https://x.com/0xxDana/status/1934603312407420961) - Whistleblower app that uses Noir to generate a ZK proof attesting that a whistleblower's email address belongs to an organization using a DKIM signature, ensuring credible disclosures while fully preserving anonymity

--- a/public/data/ai.md
+++ b/public/data/ai.md
@@ -17,7 +17,7 @@ AI systems are increasingly powerful but remain opaque, centralized, and control
 - Compute marketplaces - Decentralized GPU networks for AI training and inference with verifiable computation
 - AI governance and alignment - Onchain mechanisms for community oversight, bounties for alignment research, and transparent model evaluation
 
-## Projects
+## Examples
 
 - Compute Networks
     - [Akash](https://akash.network/) - Decentralized cloud compute marketplace

--- a/public/data/alt-money.md
+++ b/public/data/alt-money.md
@@ -16,7 +16,7 @@ Money underpins every exchange, yet the design space for monetary systems has be
 - Commodity-backed units - Monetary units redeemable for, or explicitly linked to, measurable physical resources (such as kWh of electricity, carbon units, or physical commodities), grounding value in real production capacity
 - Indexed currencies - Currencies designed to maintain stable purchasing power by algorithmically tracking inflation metrics, commodity prices, or diversified economic indicators rather than pegging to a single fiat currency
 
-## Projects
+## Examples
 
 - [Grassroots Economics](https://www.grassrootseconomics.org/) - Runs on-the-ground community currency networks in Kenya to support informal economies and local trade where cash is scarce
 - [CityCoins](https://www.citycoins.co/) - Tokens that let communities generate funding and incentives aligned with specific cities

--- a/public/data/business-ops.md
+++ b/public/data/business-ops.md
@@ -21,7 +21,7 @@ At the same time, advances in AI create the potential for organizations that cou
 - Procurement - Smart contracts for purchase orders, RFQs, RFPs, vendor agreements, or automatic replenishment plans
 - AI CEOs - Once the firm’s core systems are tokenized and software-defined, AI can act as an organizational brain&mdash;analyzing complete data flows, simulating strategies, and executing decisions onchain
 
-## Projects
+## Examples
 
 - [Mezzanine](https://www.mezzanine.xyz/) - Modular, self-custody finance OS for companies providing payments, payroll, equity, accounting, and permissions in one programmable platform
 - [Splits Teams](https://splits.org/teams/) - Programmatic profit/revenue sharing and automated team payouts

--- a/public/data/credit-and-capital-formation.md
+++ b/public/data/credit-and-capital-formation.md
@@ -18,7 +18,7 @@ Small and medium enterprises (SMEs) are underserved by traditional finance: cred
 - Credit unions - Blockchain-based cooperative finance models
 - Equity tokenization - Issuing tokenized shares, bypassing expensive IPOs and private placements
 
-## Projects
+## Examples
 
 - [3jane](https://www.3jane.xyz/) - Credit infrastructure for Web3
 - [Pact](https://pactfoundation.com/) - Cooperative credit systems

--- a/public/data/data.md
+++ b/public/data/data.md
@@ -15,7 +15,7 @@ Data already trades through brokers, ad-tech exchanges, and bespoke deals betwee
 - Fact checking oracles - Incentivize truth discovery through cryptoeconomic incentives
 - zkTLS-verified data - Users prove claims from existing web platforms&mdash;income, identity, activity&mdash;for use in onchain applications, without requiring platform permission or surrendering raw data
 
-## Projects
+## Examples
 
 - [Kled](https://www.kled.ai/) - Curated marketplace of licensed, rights-holder datasets (e.g., video, music, transcripts) for training AI models
 - [Olena](https://olena.xyz/) - Protocol for curating accurate information and peer review, leveraging quadratic funding and prediction markets

--- a/public/data/education.md
+++ b/public/data/education.md
@@ -17,7 +17,7 @@ Learners, meanwhile, lack portable, privacy-preserving credentials that can carr
 - Skill passports - Aggregated, verifiable records of learning achievements that contribute to a portable professional reputation
 - Education finance - Transparent income-share agreements, programmable scholarships, and community-driven funding for education providers
 
-## Projects
+## Examples
 
 - [BCdiploma](https://www.bcdiploma.com/) - Digital diplomas and verified micro-credentials
 - [Hyland Credentials](https://www.hyland.com/en/solutions/products/hyland-credentials) - Digital education and licensing credentials

--- a/public/data/energy.md
+++ b/public/data/energy.md
@@ -15,7 +15,7 @@ Power systems are shifting to renewables and electrification (e.g., rooftop sola
 - Carbon and sustainability accounting - Digital measurement and tracking of emissions, renewable generation, and environmental impact tied to energy production
 - Distributed grid automation - Decentralized control systems for monitoring and coordinating grid assets to reduce outages and cyber-physical vulnerabilities
 
-## Projects
+## Examples
 
 - [Glow](https://glow.org/) - A decentralized protocol designed to subsidize the production of carbon-neutral solar energy by replacing traditional carbon credits with a system of economic incentives for solar farms
 - [Daylight](https://godaylight.com/) - A decentralized energy marketplace that allows individuals and businesses to buy and sell renewable energy directly from each other

--- a/public/data/food-and-agriculture.md
+++ b/public/data/food-and-agriculture.md
@@ -17,7 +17,7 @@ In the middle, grocers and restaurants juggle siloed POS, inventory, and supplie
 - Regenerative practice incentives - Reward mechanisms that compensate farmers for sustainable and regenerative agricultural behaviors
 - Cooperative and local marketplaces - Community-owned platforms that let producers sell directly and keep more economic value within local food systems
 
-## Projects
+## Examples
 
 - [Justtoken](https://www.justoken.com/) - Tokenizing agricultural outputs (Agrotoken) and arable land (Landtoken)
 - [Farmsent](https://www.farmsent.io/) - Onchain marketplace improving farmer access to trade and capital

--- a/public/data/gaming-and-autonomous-worlds.md
+++ b/public/data/gaming-and-autonomous-worlds.md
@@ -19,7 +19,7 @@ The broader concern is that many blockchain gaming efforts today are speculative
 - Esports & leagues - Transparent tournament brackets, provable anti-cheat attestations, instant rule-based payouts reduce overhead and disputes
 - Games as coordination infrastructure - Onchain worlds could serve non-entertainment roles, like governance simulations, public-goods funding mechanisms, or training ecosystems for social cooperation or resource allocation
 
-## Projects
+## Examples
 
 - [Klang Games](https://www.klang-games.com/seed) - Large-scale life simulation MMO exploring emergent economies
 - [EVE Online](https://www.eveonline.com/) - Persistent, player-driven virtual economy and world

--- a/public/data/global-governance.md
+++ b/public/data/global-governance.md
@@ -17,7 +17,7 @@ Global and sub-national governance suffers from fragmented frameworks, inconsist
 - Space governance & digital commons - Registries for orbital slots, debris, regional airspace or global digital resources
 - City/regional protocol networks - Shared modular policy frameworks adopted by cities and regions (e.g., climate accords, mobility pacts) that reference common data protocols
 
-## Projects
+## Examples
 
 
 

--- a/public/data/hardware-and-iot.md
+++ b/public/data/hardware-and-iot.md
@@ -14,7 +14,7 @@ IoT networks&mdash;spanning smart wearables, homes, vehicles, factories, and cit
 - Machine-to-machine payments - Autonomous payment rails that let devices pay each other for services like bandwidth, energy, compute, or maintenance in real time
 - Wearables & personal sensors - Verifiable device identity and signed telemetry with consent-based sharing (to apps, clinicians, insurers), optional pay-for-data incentives or premium discounts
 
-## Projects
+## Examples
 
 - [Ethereum Reality Service](https://www.ers.to/) - Linking physical chips to onchain identifiers
 - [ERC-4519: Non-Fungible Tokens Tied to Physical Assets](https://eips.ethereum.org/EIPS/eip-4519)

--- a/public/data/health-and-bio.md
+++ b/public/data/health-and-bio.md
@@ -17,7 +17,7 @@ Healthcare suffers from siloed data, opaque supply chains, and misaligned incent
 - Biotech IP tokenization - Onchain representations of molecules, patents, or research outputs to enable new financing and licensing models
 - Programmable health insurance - Automated claims processing, fraud detection, and transparent coverage rules enforced by smart contracts
 
-## Projects
+## Examples
 
 - [Maharashtra COVID-19 certificates](https://blockchain.meity.gov.in/index.php/maharashtra-govt-onboards-blockchain-tech-for-issuing-covid-19-test-certificates) - Government-issued onchain COVID-19 test certificates
 - [OriginTrail](https://origintrail.io/) - Decentralized Knowledge Graph for medical data, counterfeit prevention, and medicine traceability, with a case study with BSI and NGOs on AidTrust for donated medicines

--- a/public/data/insurance.md
+++ b/public/data/insurance.md
@@ -16,7 +16,7 @@ Blockchain-based insurance research confirms that high transaction costs, trust 
 - Tokenized reserves & transparent solvency reporting - Onchain reserve tracking enables real-time visibility and better risk pricing
 - Tokenized policies for resale - Policies become tradable contracts, enabling secondary markets, swapping risk profiles and unlocking liquidity
 
-## Projects
+## Examples
 
 - [Ensuro](https://ensuro.co/) - Bridges DeFi capital into reinsurance
 - [Arbol](https://www.arbol.io/) - Parametric weather and risk insurance platform using smart contracts

--- a/public/data/intellectual-property.md
+++ b/public/data/intellectual-property.md
@@ -16,7 +16,7 @@ Intellectual property systems&mdash;covering patents, copyrights, and trademarks
 - Cross-industry interoperability - Enable IP licensing across IoT, media, healthcare, and scientific research
 - Proof of existence - Tamper-proof records such as lab books or drafts to strengthen "first to invention" claims
 
-## Projects
+## Examples
 
 - [license.rocks](https://license.rocks/) - IP licensing platform
 

--- a/public/data/it-infrastructure.md
+++ b/public/data/it-infrastructure.md
@@ -16,7 +16,7 @@ Provisioning and managing IT infrastructure&mdash;storage, compute, bandwidth, a
 - Inter-carrier settlement and provisioning - Shared ledgers for clearing, settlement, and coordination between networks and infrastructure providers
 - Real-time resource pricing - Pay-per-use and priority-access mechanisms for scarce resources like bandwidth, compute, or storage under contention
 
-## Projects
+## Examples
 
 - [Huddle01](https://huddle01.com/) - Decentralized video conferencing and streaming
 - [Livepeer](https://www.livepeer.org/) - Video transcoding and streaming marketplace

--- a/public/data/law-and-regulation.md
+++ b/public/data/law-and-regulation.md
@@ -21,7 +21,7 @@ At the same time, private legal agreements&mdash;wills, contracts, trusts, and d
 - Dispute resolution - Decentralized arbitration and online dispute-resolution mechanisms (e.g., Kleros) to reduce litigation overhead
 - Ricardian & parametric contracts - Human-readable, machine-parsable agreements that can execute automatically or trigger based on measurable outcomes
 
-## Projects
+## Examples
 
 - [Kleros](https://kleros.io/) - Decentralized dispute-resolution protocol using juror staking and incentive alignment
 - [Sarcophagus](https://sarcophagus.io/) - “Dead-man’s switch” for time-locked inheritance and document release

--- a/public/data/marketing-and-advertising.md
+++ b/public/data/marketing-and-advertising.md
@@ -14,7 +14,7 @@ Digital advertising is dominated by centralized platforms that control audience 
 - Programmable ad spend - Direct funding of dapps or public goods via ad revenue
 - Tokenized loyalty and rewards - Integrating ad campaigns with consumer incentives
 
-## Projects
+## Examples
 
 - [The Miracle](https://www.themiracle.io/) - Target & activate crypto users
 - [DaisyPay](https://daisypay.app/) - Pays creators in stablecoins for zkTLS-verified social engagement, replacing intermediaries with direct brand-to-creator payments

--- a/public/data/media-and-entertainment.md
+++ b/public/data/media-and-entertainment.md
@@ -16,7 +16,7 @@ Cultural production and distribution is bottlenecked by centralized intermediari
 - Decentralized streaming and publishing - Censorship-resistant platforms for content distribution
 - Verifiable journalism - Provenance for media assets and claims, linked to fact-checking oracles
 
-## Projects
+## Examples
 
 - [Soneium](https://soneium.org/) - Sony’s L2 focused on royalty automation & creator-owned IP ([Explainer article](https://enterpriseonchain.substack.com/p/sonys-entertainment-layer-2-explored))
 - Events & Ticketing

--- a/public/data/philanthropy-and-social-services.md
+++ b/public/data/philanthropy-and-social-services.md
@@ -17,7 +17,7 @@ Mobilizing resources for aid and social support is often slow, opaque and costly
 - Decentralized coordination for social-services actors - Infrastructure enabling NGOs, volunteers and communities to coordinate service delivery, funding and verification
 - UBI - Direct-to-recipient distribution mechanisms that provide recurring, automated universal basic income payments, using decentralized identity and smart contracts to reduce administrative overhead
 
-## Projects
+## Examples
 
 - [Endaoment](https://endaoment.org/) - Crypto-based donor-advised fund platform for charities
 - [Gitcoin](https://www.gitcoin.co/) - Web3 funding platform for public-goods, including social-impact projects

--- a/public/data/productivity-and-collaboration.md
+++ b/public/data/productivity-and-collaboration.md
@@ -16,7 +16,7 @@ Workplace productivity today is dominated by centralized SaaS providers who silo
 - Code collaboration & peer-governance - P2P versioning and funding for open source, with contributor credentials, governance tokens and transparent reward flows
 - Potential for “collaboration infrastructure” - Ethereum-based protocols could serve as a shared workflow layer across enterprises, enabling plug-and-play modules for documents, identity, governance and contributions
 
-## Projects
+## Examples
 
 - [Towns](https://www.towns.com/) - Community chat and coordination platform aiming at user-owned collaboration
 - [Common Ground](https://www.commonground.cg/) - Onchain attestations, reputation tracking, community wallets for work contributions

--- a/public/data/public-administration.md
+++ b/public/data/public-administration.md
@@ -17,7 +17,7 @@ Citizens often face duplicative verification processes, long wait times, paper-b
 - Participatory governance - E-voting, participatory budgeting, petitions and citizen consultation platforms anchored on ledger systems
 - Digital public infrastructure (DPI) - Interoperable APIs and secure data-exchanges enabling cross-agency coordination
 
-## Projects
+## Examples
 
 - [Bhutan NDI](https://www.bhutanndi.com/) - The world's first national identity system based on Self-Sovereign Identity (SSI) technology, providing citizens with a secure digital wallet to manage their credentials and access services ([Learn more here](https://x.com/AyaMiyagotchi/status/1977798764485361966))
 - [QuarkID](https://quarkid.org/) - SSI protocol for managing essential personal documents such as birth and marriage certificates, academic credentials, and proof of income, developed by the government of Buenos Aires for use in Argentina and other South American countries

--- a/public/data/public-finance-and-procurement.md
+++ b/public/data/public-finance-and-procurement.md
@@ -19,7 +19,7 @@ Government financial systems and procurement workflows often operate with fragme
 - Supplier certification, registration & audit trails - Shared digital passports for suppliers, transparent contract-award workflows and tamper-proof audit-logs
 - Requisition-to-pay ledger integration - Smart contracts bridging PO issuance, supplier delivery, inspection, invoice and payment in a unified chain
 
-## Projects
+## Examples
 
 - [BYC Ventures](https://byc.ventures/) - Pilot in the Philippines tracking government spending via ledger-anchored document hashing
 - U.S. Chamber of Commerce pilot - Department of Commerce hashed GDP data to enhance transparency of official statistics

--- a/public/data/real-estate-and-housing.md
+++ b/public/data/real-estate-and-housing.md
@@ -15,7 +15,7 @@ Real estate transactions require many intermediaries, including brokers, title c
 - Onchain mortgage & home-equity rails - Servicing and secondary markets become programmable, traceable and accessible
 - Community ownership primitives - Co-ops and land trusts based on token-governance enable inclusive ownership and local alignment
 
-## Projects
+## Examples
 
 - [Propy](https://propy.com/) - Onchain title and escrow platform recording property transfers via smart contracts
 - [Fabrica](https://fabrica.land/) - Purchase and hold land parcels as NFTs linked to real-world properties

--- a/public/data/retail-and-ecommerce.md
+++ b/public/data/retail-and-ecommerce.md
@@ -18,7 +18,7 @@ Retail and e-commerce workflows require stitching together product sourcing, inv
 - Autonomous auctions - Where goods can be priced and sold without an intermediary
 - Full Commerce Stack - Potential for integrating supply-chain provenance, dynamic pricing and loyalty token-flows in one unified commerce stack
 
-## Projects
+## Examples
 
 - [FreePay](https://freepaypos.org/) - Intermediary-free payment terminal for merchants accepting crypto
 - [Commerce Payments Protocol](https://shopify.engineering/commerce-payments-protocol) - by Shopify & Coinbase to bring the two-step "auth & capture" flow onchain for merchant payments

--- a/public/data/science-and-research.md
+++ b/public/data/science-and-research.md
@@ -17,7 +17,7 @@ Scientific research is strained by misaligned incentives and weak accountability
 - Knowledge graphs & connected science - Decentralized knowledge graphs linking data, AI, and researchers to reveal hidden connections
 - Prediction markets & crowdsourced innovation - Incentivized mechanisms for funding and discovering novel research directions
 
-## Projects
+## Examples
 
 - [Molecule](https://molecule.xyz/) - Crowdfunded biopharma protocol with milestone-based governance
 - [Bio.xyz](https://www.bio.xyz) - Tokenized IP platform for biotech research

--- a/public/data/security-and-defense.md
+++ b/public/data/security-and-defense.md
@@ -16,7 +16,7 @@ National defense and critical infrastructure increasingly depend on digital syst
 - Supply-chain provenance for defense hardware - Immutable tracking of parts, maintenance histories and provenance for weapons-systems and components
 - Decentralized decision-aid networks - Secure sharing and verification of AI-model updates, sensor-data cross-validation in multi-domain operations
 
-## Projects
+## Examples
 
 
 ## Resources

--- a/public/data/services-and-tasks.md
+++ b/public/data/services-and-tasks.md
@@ -19,7 +19,7 @@ Trust between counterparties remains fragile: reviews are easily gamed, disputes
 - Task credentials - Cryptographic proofs of work, verified deliverable receipts, or NFT-based certificates that unlock access to higher-value opportunities
 - Decentralized arbitration systems - Mediation solutions for labor contracting arrangements that ensure efficient and fair dispute outcomes
 
-## Projects
+## Examples
 
 - [Human Protocol](https://humanprotocol.org/) - Framework for decentralized microtask coordination and reward distribution
 - [time.fun](http://time.fun/) - Tokenized marketplace for booking time-based services

--- a/public/data/social.md
+++ b/public/data/social.md
@@ -18,7 +18,7 @@ Today’s social platforms concentrate power in a small number of large companie
 - Credential/token-gated groups & curation mechanisms - For example, graduates of a specific university, attendee networks, token-curated registries (TCRs), staking games, curated communities
 - Crowdfunding & incentivizing real-world actions - Mechanisms to tie social participation to offline actions
 
-## Projects
+## Examples
 
 - [Farcaster](https://docs.farcaster.xyz/learn/) - A decentralized social graph protocol enabling user-owned identity and interoperable social apps
 - [Zora](https://zora.co/) - Onchain creator monetization and media-minting platform where creators issue tokens for content

--- a/public/data/supply-chain.md
+++ b/public/data/supply-chain.md
@@ -18,7 +18,7 @@ Global supply chains today are highly fragmented, largely paper-driven, and pron
 - Open supply-chains - Enabling coordination among independent farmers, artisans and open-hardware producers outside corporate platforms
 - Electronic Bill of Lading - Replacing paper document of title with NFT-like digital representation of title and transfer rights
 
-## Projects
+## Examples
 
 - [EY OpsChain Traceability](https://blockchain.ey.com/products/traceability) - Tokenized assets and inventory under privacy for more accurate forecasting and reduced administrative overhead
 - [EY Nightfall](https://polygon.technology/blog/introducing-polygon-nightfall-mainnet-decentralized-private-transactions-for-enterprise) - Private supply chain orchestration with traceability, provenance proofs, and payments

--- a/public/data/sustainability-and-regeneration.md
+++ b/public/data/sustainability-and-regeneration.md
@@ -15,7 +15,7 @@ Many natural assets&mdash;such as water, forests and mineral resources&mdash;are
 - Quality-tiered environmental assets - Differentiating asset classes by methodology, provenance, verification quality and governance, enabling transparency across markets
 - Outcome-linked finance with milestones - Smart-contract-based release of funds or credits when independently verifiable events occur (e.g., reforestation, water-quality improvement)
 
-## Projects
+## Examples
 
 - [Climate Action Data](https://climateactiondata.org/registries/) - Digital infrastructure connecting environmental registries, maximising transparency of carbon credits and minimising double-counting
 - [Regen Network](https://www.regen.network/) - Ecological state-machine and environmental-credit market based on onchain infrastructure

--- a/public/data/transport-and-logistics.md
+++ b/public/data/transport-and-logistics.md
@@ -19,7 +19,7 @@ With the rise of connected and autonomous vehicles, the requirement for audit tr
 - Digital vehicle passports - End-to-end, tamper-evident records covering manufacturing, ownership, maintenance, accidents, and recycling
 - Automated logistics payments - Verifiable location and event proofs that trigger payments or contract execution in transport and supply chains
 
-## Projects
+## Examples
 
 - [DIMO](https://dimo.co/) - Vehicle data sharing network enabling fleet telemetry and provenance
 - [Rentality](https://rentality.io/) - Decentralized car-rental marketplace

--- a/public/data/travel.md
+++ b/public/data/travel.md
@@ -15,7 +15,7 @@ Travel is held back by fragmented identity and compliance checks, siloed reserva
 - Parametric travel insurance - Automatic insurance payouts triggered by verifiable events such as delays, cancellations, or lost baggage
 - Tokenized travel inventory - Onchain representations of tickets and reservations that enable resale, bundling, and dynamic packaging
 
-## Projects
+## Examples
 
 - [Dtravel](https://www.dtravel.com/) - DAO‑aligned vacation rentals with onchain payments
 - [Buk Protocol](https://bukprotocol.ai/) - Tokenized hotel inventory and bookings

--- a/utils.ts
+++ b/utils.ts
@@ -96,7 +96,7 @@ export const parseDomainMarkdown = (markdown: string, existingData: DomainData):
     } else if (header.startsWith('ideas')) {
       // Parse ideas with format: - idea name - description
       allIdeas = [...allIdeas, ...parseIdeasBulletFormat(content)];
-    } else if (header.startsWith('projects')) {
+    } else if (header.startsWith('examples')) {
       // Parse projects with format: - [name](url) - description
       allProjects = [...allProjects, ...parseProjectsBulletFormat(content)];
     } else if (header.startsWith('resources')) {


### PR DESCRIPTION
## Summary
- Renames the `## Projects` markdown header to `## Examples` across all 33 domain data files
- Updates the markdown parser in `utils.ts` to match the new `examples` header
- Updates the UI heading in `OverviewTab.tsx`
- Updates the PR template to reflect the new section name

## Test plan
- [ ] Verify domain pages render correctly with the "Examples" section header
- [ ] Confirm the parser correctly picks up entries under `## Examples`
- [ ] Check PR template reflects updated section name

🤖 Generated with [Claude Code](https://claude.com/claude-code)