### PR TITLE
Fix domain naming inconsistencies in frontmatter

### DIFF
--- a/public/data/gaming-and-autonomous-worlds.md
+++ b/public/data/gaming-and-autonomous-worlds.md
@@ -1,6 +1,6 @@
 ---
-title: Gaming and Autonomous Worlds
-sector: Unknown
+title: Gaming & Autonomous Worlds
+sector: Consumer
 ---
 
 ## The Opportunity

--- a/public/data/retail-and-ecommerce.md
+++ b/public/data/retail-and-ecommerce.md
@@ -1,5 +1,5 @@
 ---
-title: Retail & E-Commerce
+title: Retail & eCommerce
 sector: Consumer
 ---
 


### PR DESCRIPTION
## Summary
- **Retail & eCommerce**: Fixed frontmatter title from `Retail & E-Commerce` to `Retail & eCommerce` to match `constants.ts` and `server.js`
- **Gaming & Autonomous Worlds**: Fixed frontmatter title from `Gaming and Autonomous Worlds` to `Gaming & Autonomous Worlds` (uses `&` like every other domain file)
- **Gaming & Autonomous Worlds**: Fixed sector from `Unknown` to `Consumer` to match category mapping in `constants.ts`

## Test plan
- [ ] Verify both domains render with correct titles in the sidebar and overview
- [ ] Verify Gaming appears under the Consumer category

🤖 Generated with [Claude Code](https://claude.com/claude-code)