### PR TITLE
Replace header GitHub link with Submit an Idea CTA

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import IdeaShowcase, { getDomainConfig, parseIdeaMarkdown } from './components/IdeaShowcase';
 import IdeaPage, { IdeaEntry } from './components/IdeaPage';
 import ToolkitPage from './components/ToolkitPage';
-import { ArrowUpRight, Wrench, Copy, Check } from 'lucide-react';
+import { Wrench, Copy, Check, Plus } from 'lucide-react';
 
 function parseRoute(): { page: 'home' } | { page: 'idea'; ideaId: string } | { page: 'toolkit' } {
   const path = window.location.pathname;
@@ -149,20 +149,13 @@ const App: React.FC = () => {
             <Wrench className="w-3 h-3" /> Toolkit
           </button>
           <a
-            href="https://www.usecaselab.org/"
+            href={`https://github.com/usecaselab/explorer/issues/new?template=use-case-submission.md&title=${encodeURIComponent('[Use Case] ')}&body=${encodeURIComponent(`## Idea\n\n\n## Problem it solves\n\n\n## Relevant domains\n\n\n## Links or references\n\n`)}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-xs sm:text-sm text-gray-500 hover:text-black transition-colors flex items-center gap-1"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 sm:px-4 sm:py-2 bg-black text-white text-xs sm:text-sm font-medium rounded-lg hover:bg-gray-800 transition-colors"
           >
-            About <ArrowUpRight className="w-3 h-3" />
-          </a>
-          <a
-            href="https://github.com/usecaselab"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="hidden sm:flex text-sm text-gray-500 hover:text-black transition-colors items-center gap-1"
-          >
-            GitHub <ArrowUpRight className="w-3 h-3" />
+            <Plus className="w-3.5 h-3.5" />
+            Submit an Idea
           </a>
         </nav>
       </header>

--- a/components/IdeaPage.tsx
+++ b/components/IdeaPage.tsx
@@ -18,7 +18,6 @@ export interface IdeaEntry {
   whyEthereum: string
   domains: string[]
   resources: IdeaResource[]
-  examples?: IdeaResource[]
 }
 
 function domainLabel(d: string): string {
@@ -156,38 +155,6 @@ export default function IdeaPage({ idea, accentColor, onBack, allIdeas = [], onS
               <p className="text-lg text-gray-700 leading-relaxed">
                 {renderMarkdownLinks(whyExplanation)}
               </p>
-            </div>
-          </section>
-        )}
-
-        {/* Examples */}
-        {idea.examples && idea.examples.length > 0 && (
-          <section>
-            <h2 className="font-heading text-sm font-bold uppercase tracking-widest text-gray-400 mb-6">
-              Who's Building
-            </h2>
-            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-              {idea.examples.map((example, idx) => (
-                <a
-                  key={idx}
-                  href={example.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="group p-4 sm:p-5 rounded-xl border border-gray-100 hover:border-gray-200 transition-colors"
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <h3 className="font-heading text-sm font-bold text-black">
-                      {example.name}
-                    </h3>
-                    <ExternalLink className="w-3.5 h-3.5 text-gray-300 group-hover:text-black transition-colors flex-shrink-0 mt-0.5" />
-                  </div>
-                  {example.description && (
-                    <p className="text-sm text-gray-500 leading-relaxed mt-1.5">
-                      {renderMarkdownLinks(example.description)}
-                    </p>
-                  )}
-                </a>
-              ))}
             </div>
           </section>
         )}

--- a/components/IdeaShowcase.tsx
+++ b/components/IdeaShowcase.tsx
@@ -78,7 +78,6 @@ function parseIdeaMarkdown(content: string, id: string): IdeaEntry {
     whyEthereum: parseSection(body, 'Why Ethereum'),
     domains: (meta.domains || '').split(',').map(d => d.trim()).filter(Boolean),
     resources: parseLinks(body, 'Resources'),
-    examples: parseLinks(body, 'Examples'),
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace the header GitHub link with a prominent **Submit an Idea** button that opens a pre-filled new-issue form using the `use-case-submission` template
- Drop the About link from the header
- Remove the "Who's Building" section on idea pages — it was populated on only 6 of 122 ideas (Powerhouse ×3, Aragon ×3)

## Test plan
- [ ] Header renders the black "Submit an Idea" pill on both mobile and desktop
- [ ] Clicking it opens a GitHub new-issue page pre-filled with the use-case template
- [ ] About link is gone
- [ ] Idea pages no longer show a "Who's Building" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)