### PR TITLE
Add Coolify deploy trigger alongside GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,3 +51,15 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  deploy-coolify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Coolify deployment
+        run: |
+          response=$(curl -s -o /tmp/body -w "%{http_code}" \
+            -H "Authorization: Bearer ${{ secrets.COOLIFY_TOKEN }}" \
+            "https://coolify.pblvrt.com/api/v1/deploy?uuid=ncg4ssc0kso8s4cw4kg80wgc&force=false")
+          echo "HTTP $response"
+          cat /tmp/body
+          test "$response" = "200"


### PR DESCRIPTION
## Summary
- `explorer.usecaselab.org` is served by Coolify (app UUID `ncg4ssc0kso8s4cw4kg80wgc`), not GitHub Pages — today's pushes updated Pages but the live site was stuck on a March 25 build.
- Adds a `deploy-coolify` job that calls Coolify's `/api/v1/deploy` endpoint on every push to `main`, in parallel with the existing Pages deploy.
- Requires repo secret `COOLIFY_TOKEN` (already configured, Bearer token scoped to the Coolify instance).

## Test plan
- [ ] Merge, then check that a new deployment appears in Coolify for explorer (app 68)
- [ ] Confirm `explorer.usecaselab.org` serves the latest commit's build after the run finishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)