### PR TITLE
Hotfix: drop --env-file-if-exists flag (Node 20 incompat)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "dev:server": "node --env-file-if-exists=.env server.js",
+    "dev:server": "node --env-file=.env server.js",
     "build": "vite build",
     "preview": "vite preview",
-    "start": "node --env-file-if-exists=.env server.js"
+    "start": "node server.js"
   },
   "dependencies": {
     "@google/genai": "^1.30.0",


### PR DESCRIPTION
## Summary
- The \`start\` and \`dev:server\` scripts use \`--env-file-if-exists=.env\`, which requires Node ≥22.7.0.
- Coolify's Nixpacks builds with Node 20, so the flag is parsed as the filename and the container crash-loops with \`node: .env: not found\`.
- Production (\`explorer.usecaselab.org\`) has been crash-looping since the morning's merge to main.

## Fix
- \`start\` → \`node server.js\` (Coolify injects env via Docker -e; no file needed in prod).
- \`dev:server\` → \`node --env-file=.env server.js\` (older flag, supported on Node ≥20.6).

## Test plan
- [x] Built and deployed dev (\`feature/social-auth-db\` with the same fix); container starts cleanly, SQLite seeds, /api/ideas serves.
- [ ] Merge → Coolify auto-redeploys prod → verify \`https://explorer.usecaselab.org\` returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)