### PR TITLE
Hotfix: drop users.email scope on Twitter provider

### DIFF
--- a/server/auth.js
+++ b/server/auth.js
@@ -14,6 +14,10 @@ if (process.env.TWITTER_CLIENT_ID && process.env.TWITTER_CLIENT_SECRET) {
   socialProviders.twitter = {
     clientId: process.env.TWITTER_CLIENT_ID,
     clientSecret: process.env.TWITTER_CLIENT_SECRET,
+    // X requires apps to enable "Request email from users" (with privacy/ToS URLs)
+    // to grant the users.email scope. Skip it; Better Auth falls back to username.
+    disableDefaultScope: true,
+    scope: ['users.read', 'tweet.read', 'offline.access'],
   };
 }
 


### PR DESCRIPTION
## Summary
X requires the OAuth app to have *Request email from users* enabled (with privacy/ToS URLs filed) before it grants the \`users.email\` scope. Without that, Better Auth's post-callback profile fetch fails with \`unable_to_get_user_info\`.

This patch sets \`disableDefaultScope: true\` and explicitly requests only \`users.read tweet.read offline.access\` on the twitter provider.

## Test plan
- [x] Verified on dev — Twitter sign-in completes after redeploy.
- [ ] Merge → prod redeploys → \`https://explorer.usecaselab.org\` Twitter sign-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)