### PR TITLE
Add touch and keyboard support to the persona graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ dist
 dist-ssr
 *.local
 
+# Playwright
+test-results
+playwright-report
+.playwright
+
 # Local env
 .env
 .env.local

--- a/components/GraphView.tsx
+++ b/components/GraphView.tsx
@@ -131,7 +131,12 @@ export default function GraphView({
   const containerRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
   const [size, setSize] = useState({ w: 0, h: 0 })
+  // `hover` is mouse-only; `pinned` is the touch/keyboard selection. The graph
+  // highlights whichever is set — `active` below merges them.
   const [hover, setHover] = useState<Hover>(null)
+  const [pinned, setPinned] = useState<Hover>(null)
+  const [focusedPersona, setFocusedPersona] = useState<string | null>(null)
+  const active: Hover = hover ?? pinned
   const [view, setView] = useState({ x: 0, y: 0, k: 1 })
   const viewRef = useRef(view)
   viewRef.current = view
@@ -139,6 +144,10 @@ export default function GraphView({
   // pan state
   const dragRef = useRef<{ sx: number; sy: number; ox: number; oy: number; moved: boolean } | null>(null)
   const suppressClickRef = useRef(false)
+  // Active pointers (mouse/touch/pen unified). Two = pinch-zoom.
+  const pointersRef = useRef<Map<number, { x: number; y: number }>>(new Map())
+  const pinchRef = useRef<{ startDist: number; startK: number; wx: number; wy: number } | null>(null)
+  const lastPointerTypeRef = useRef<string>('mouse')
 
   // Measure the container.
   useEffect(() => {
@@ -201,22 +210,71 @@ export default function GraphView({
     [ideas, q, searchActive]
   )
 
-  // Nodes connected to the hovered node.
+  // Nodes connected to the active (hovered/pinned/focused) node.
   const activeIdeas = useMemo(() => {
-    if (!hover || !layout) return null
-    if (hover.type === 'persona') return new Set(layout.personaToIdeas[hover.id] || [])
-    return new Set([hover.id])
-  }, [hover, layout])
+    if (!active || !layout) return null
+    if (active.type === 'persona') return new Set(layout.personaToIdeas[active.id] || [])
+    return new Set([active.id])
+  }, [active, layout])
   const activePersonas = useMemo(() => {
-    if (!hover || !layout) return null
-    if (hover.type === 'idea') return new Set(layout.ideaToPersonas[hover.id] || [])
-    return new Set([hover.id])
-  }, [hover, layout])
+    if (!active || !layout) return null
+    if (active.type === 'idea') return new Set(layout.ideaToPersonas[active.id] || [])
+    return new Set([active.id])
+  }, [active, layout])
 
-  const onMouseDown = (e: React.MouseEvent) => {
-    dragRef.current = { sx: e.clientX, sy: e.clientY, ox: view.x, oy: view.y, moved: false }
+  // Zoom toward a point in svg-local coordinates, keeping that point fixed.
+  const zoomAt = (factor: number, px: number, py: number) => {
+    const v = viewRef.current
+    const k = Math.min(4, Math.max(0.5, v.k * factor))
+    const wx = (px - v.x) / v.k
+    const wy = (py - v.y) / v.k
+    setView({ k, x: px - wx * k, y: py - wy * k })
   }
-  const onMouseMove = (e: React.MouseEvent) => {
+  const zoomBy = (factor: number) => zoomAt(factor, size.w / 2, size.h / 2)
+  const resetView = () => setView({ x: 0, y: 0, k: 1 })
+
+  // Unified pointer handling: one pointer pans, two pinch-zoom. Covers mouse,
+  // touch and pen, so there is no separate touch code path.
+  const onPointerDown = (e: React.PointerEvent) => {
+    lastPointerTypeRef.current = e.pointerType
+    pointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY })
+    const n = pointersRef.current.size
+    if (n === 2) {
+      const svg = svgRef.current
+      if (!svg) return
+      const [a, b] = [...pointersRef.current.values()]
+      const rect = svg.getBoundingClientRect()
+      const mx = (a.x + b.x) / 2 - rect.left
+      const my = (a.y + b.y) / 2 - rect.top
+      const v = viewRef.current
+      pinchRef.current = {
+        startDist: Math.hypot(a.x - b.x, a.y - b.y) || 1,
+        startK: v.k,
+        wx: (mx - v.x) / v.k,
+        wy: (my - v.y) / v.k,
+      }
+      dragRef.current = null // a second finger cancels any in-flight pan
+    } else if (n === 1) {
+      const v = viewRef.current
+      dragRef.current = { sx: e.clientX, sy: e.clientY, ox: v.x, oy: v.y, moved: false }
+    }
+  }
+  const onPointerMove = (e: React.PointerEvent) => {
+    if (!pointersRef.current.has(e.pointerId)) return
+    pointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY })
+    if (pinchRef.current && pointersRef.current.size >= 2) {
+      const svg = svgRef.current
+      if (!svg) return
+      const [a, b] = [...pointersRef.current.values()]
+      const rect = svg.getBoundingClientRect()
+      const mx = (a.x + b.x) / 2 - rect.left
+      const my = (a.y + b.y) / 2 - rect.top
+      const dist = Math.hypot(a.x - b.x, a.y - b.y)
+      const p = pinchRef.current
+      const k = Math.min(4, Math.max(0.5, p.startK * (dist / p.startDist)))
+      setView({ k, x: mx - p.wx * k, y: my - p.wy * k })
+      return
+    }
     const d = dragRef.current
     if (!d) return
     const dx = e.clientX - d.sx
@@ -224,14 +282,75 @@ export default function GraphView({
     if (!d.moved && Math.hypot(dx, dy) > 4) d.moved = true
     if (d.moved) setView((v) => ({ ...v, x: d.ox + dx, y: d.oy + dy }))
   }
-  const endDrag = () => {
+  const onPointerUp = (e: React.PointerEvent) => {
+    const wasTap = !!dragRef.current && !dragRef.current.moved
     if (dragRef.current?.moved) {
       suppressClickRef.current = true
       setTimeout(() => {
         suppressClickRef.current = false
       }, 0)
     }
-    dragRef.current = null
+    // A tap on empty canvas clears the pinned (touch) selection.
+    if (wasTap && e.pointerType !== 'mouse' && e.target === svgRef.current) setPinned(null)
+    pointersRef.current.delete(e.pointerId)
+    if (pointersRef.current.size < 2) pinchRef.current = null
+    if (pointersRef.current.size === 1) {
+      // Lifting one finger of a pinch: hand the remaining finger to pan.
+      const [pt] = [...pointersRef.current.values()]
+      const v = viewRef.current
+      dragRef.current = { sx: pt.x, sy: pt.y, ox: v.x, oy: v.y, moved: true }
+    } else if (pointersRef.current.size === 0) {
+      dragRef.current = null
+    }
+  }
+
+  // Touch/pen tap is two-stage: first tap pins (highlights connections), a
+  // second tap on the same node activates it. Mouse clicks activate directly.
+  const activate = (sel: Exclude<Hover, null>, run: () => void) => {
+    if (suppressClickRef.current) return
+    if (lastPointerTypeRef.current === 'mouse') {
+      run()
+      return
+    }
+    if (pinned && pinned.type === sel.type && pinned.id === sel.id) run()
+    else setPinned(sel)
+  }
+
+  // Keyboard control of the canvas: arrows pan, +/- zoom, 0 resets, Esc clears.
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    const step = 60
+    switch (e.key) {
+      case 'ArrowLeft':
+        setView((v) => ({ ...v, x: v.x + step }))
+        break
+      case 'ArrowRight':
+        setView((v) => ({ ...v, x: v.x - step }))
+        break
+      case 'ArrowUp':
+        setView((v) => ({ ...v, y: v.y + step }))
+        break
+      case 'ArrowDown':
+        setView((v) => ({ ...v, y: v.y - step }))
+        break
+      case '+':
+      case '=':
+        zoomBy(1.2)
+        break
+      case '-':
+      case '_':
+        zoomBy(1 / 1.2)
+        break
+      case '0':
+        resetView()
+        break
+      case 'Escape':
+        setHover(null)
+        setPinned(null)
+        break
+      default:
+        return
+    }
+    e.preventDefault()
   }
 
   // Render the container unconditionally — even before data arrives — so its
@@ -241,7 +360,7 @@ export default function GraphView({
   const dataLoading = personas.length === 0 || ideas.length === 0
 
   const isHighlightedEdge = (pid: string, iid: string) =>
-    hover != null && (hover.type === 'persona' ? hover.id === pid : hover.id === iid)
+    active != null && (active.type === 'persona' ? active.id === pid : active.id === iid)
 
   return (
     <section className="w-full flex-1 flex flex-col">
@@ -253,15 +372,19 @@ export default function GraphView({
           ref={svgRef}
           width="100%"
           height="100%"
-          className="absolute inset-0 select-none"
+          tabIndex={0}
+          role="application"
+          aria-label="Persona and idea graph. Drag to pan, scroll or pinch to zoom. Arrow keys pan, plus and minus zoom, 0 resets."
+          className="absolute inset-0 select-none touch-none focus:outline-none"
           style={{ cursor: dragRef.current?.moved ? 'grabbing' : 'grab' }}
-          onMouseDown={onMouseDown}
-          onMouseMove={onMouseMove}
-          onMouseUp={endDrag}
-          onMouseLeave={() => {
-            endDrag()
-            setHover(null)
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerUp}
+          onPointerLeave={(e) => {
+            if (e.pointerType === 'mouse') setHover(null)
           }}
+          onKeyDown={onKeyDown}
         >
           {layout && (
             <g transform={`translate(${view.x} ${view.y}) scale(${view.k})`}>
@@ -280,7 +403,7 @@ export default function GraphView({
                     y2={b.y}
                     stroke="#94a3b8"
                     strokeWidth={1}
-                    opacity={hover ? 0.05 : 0.16}
+                    opacity={active ? 0.05 : 0.16}
                   />
                 )
               })}
@@ -308,43 +431,48 @@ export default function GraphView({
               {ideas.map((idea) => {
                 const pos = layout.ideaPos[idea.id]
                 if (!pos) return null
-                const isHovered = hover?.type === 'idea' && hover.id === idea.id
+                const isActive = active?.type === 'idea' && active.id === idea.id
                 const isMatch = !!matchedIdeas?.has(idea.id)
-                const emphasized = isHovered || isMatch
+                const emphasized = isActive || isMatch
                 const dim = activeIdeas
                   ? !activeIdeas.has(idea.id)
                   : searchActive
                     ? !isMatch
                     : false
                 const showLabel =
-                  isHovered ||
+                  isActive ||
                   isMatch ||
-                  (hover?.type === 'persona' && !!activeIdeas?.has(idea.id))
+                  (active?.type === 'persona' && !!activeIdeas?.has(idea.id))
                 const side = emphasized ? 17 : 12
                 const lw = idea.title.length * 6.5 + 16
+                const openIdea = () => {
+                  const row = ideaById.get(idea.id)
+                  if (row) {
+                    onSelectIdea({
+                      id: row.id,
+                      title: row.title,
+                      problem: row.problem,
+                      solutionSketch: row.solutionSketch,
+                      whyEthereum: row.whyEthereum,
+                      domains: row.domains,
+                      author: row.author,
+                      createdAt: row.createdAt,
+                      updatedAt: row.updatedAt,
+                    })
+                  }
+                }
                 return (
                   <g
                     key={idea.id}
                     style={{ cursor: 'pointer' }}
-                    onMouseEnter={() => setHover({ type: 'idea', id: idea.id })}
-                    onMouseLeave={() => setHover(null)}
-                    onClick={() => {
-                      if (suppressClickRef.current) return
-                      const row = ideaById.get(idea.id)
-                      if (row) {
-                        onSelectIdea({
-                          id: row.id,
-                          title: row.title,
-                          problem: row.problem,
-                          solutionSketch: row.solutionSketch,
-                          whyEthereum: row.whyEthereum,
-                          domains: row.domains,
-                          author: row.author,
-                          createdAt: row.createdAt,
-                          updatedAt: row.updatedAt,
-                        })
-                      }
+                    onPointerEnter={(e) => {
+                      if (e.pointerType === 'mouse' && !dragRef.current?.moved)
+                        setHover({ type: 'idea', id: idea.id })
                     }}
+                    onPointerLeave={(e) => {
+                      if (e.pointerType === 'mouse') setHover(null)
+                    }}
+                    onClick={() => activate({ type: 'idea', id: idea.id }, openIdea)}
                   >
                     <circle cx={pos.x} cy={pos.y} r={19} fill="transparent" pointerEvents="all" />
                     <rect
@@ -389,9 +517,10 @@ export default function GraphView({
                 if (!pos) return null
                 const color = personaColor(p.id)
                 const Icon = personaIcon(p.id)
-                const isHovered = hover?.type === 'persona' && hover.id === p.id
+                const isActive = active?.type === 'persona' && active.id === p.id
                 const isMatch = !!matchedPersonas?.has(p.id)
-                const emphasized = isHovered || isMatch
+                const emphasized = isActive || isMatch
+                const isFocused = focusedPersona === p.id
                 const dim = activePersonas
                   ? !activePersonas.has(p.id)
                   : searchActive
@@ -402,14 +531,46 @@ export default function GraphView({
                 return (
                   <g
                     key={p.id}
-                    style={{ cursor: 'pointer' }}
-                    onMouseEnter={() => setHover({ type: 'persona', id: p.id })}
-                    onMouseLeave={() => setHover(null)}
-                    onClick={() => {
-                      if (!suppressClickRef.current) onSelectPersona(p.id)
+                    tabIndex={0}
+                    role="button"
+                    aria-label={`Persona: ${p.name}. Activate to open, or hold focus to highlight connected ideas.`}
+                    style={{ cursor: 'pointer', outline: 'none' }}
+                    onPointerEnter={(e) => {
+                      if (e.pointerType === 'mouse' && !dragRef.current?.moved)
+                        setHover({ type: 'persona', id: p.id })
                     }}
+                    onPointerLeave={(e) => {
+                      if (e.pointerType === 'mouse') setHover(null)
+                    }}
+                    onFocus={() => {
+                      setFocusedPersona(p.id)
+                      setHover({ type: 'persona', id: p.id })
+                    }}
+                    onBlur={() => {
+                      setFocusedPersona((cur) => (cur === p.id ? null : cur))
+                      setHover((cur) => (cur?.type === 'persona' && cur.id === p.id ? null : cur))
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        e.stopPropagation()
+                        onSelectPersona(p.id)
+                      }
+                    }}
+                    onClick={() => activate({ type: 'persona', id: p.id }, () => onSelectPersona(p.id))}
                   >
                     <circle cx={pos.x} cy={pos.y} r={r + 10} fill="transparent" pointerEvents="all" />
+                    {isFocused && (
+                      <circle
+                        cx={pos.x}
+                        cy={pos.y}
+                        r={r + 5}
+                        fill="none"
+                        stroke={color}
+                        strokeWidth={2.5}
+                        opacity={0.9}
+                      />
+                    )}
                     <g opacity={dim ? 0.22 : 1} style={{ pointerEvents: 'none' }}>
                       <circle cx={pos.x} cy={pos.y} r={r} fill={color} />
                       <Icon

--- a/e2e/graph.spec.ts
+++ b/e2e/graph.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect, Page } from '@playwright/test'
+
+// The transformed group carries the pan/zoom state as
+// `translate(x y) scale(k)`. Reading it back is the cleanest observable for
+// asserting that an interaction moved or zoomed the view.
+async function getView(page: Page): Promise<{ x: number; y: number; k: number }> {
+  const g = page.locator('svg[role="application"] > g[transform^="translate"]').first()
+  const t = await g.getAttribute('transform')
+  const m = t?.match(/translate\(([-\d.]+) ([-\d.]+)\) scale\(([-\d.]+)\)/)
+  if (!m) throw new Error(`could not parse transform: ${t}`)
+  return { x: parseFloat(m[1]), y: parseFloat(m[2]), k: parseFloat(m[3]) }
+}
+
+// Wait for the graph to have rendered its transformed group (data loaded,
+// layout computed).
+async function waitForGraph(page: Page) {
+  await page.locator('svg[role="application"] > g[transform^="translate"]').first().waitFor()
+}
+
+test.describe('graph keyboard control', () => {
+  test('arrows pan, +/- zoom, 0 resets', async ({ page }) => {
+    await page.goto('/')
+    await waitForGraph(page)
+
+    const svg = page.locator('svg[role="application"]')
+    await svg.focus()
+
+    const before = await getView(page)
+
+    // ArrowRight pans the view left by a fixed step (x decreases).
+    await page.keyboard.press('ArrowRight')
+    const afterPan = await getView(page)
+    expect(afterPan.x).toBeLessThan(before.x)
+    expect(afterPan.k).toBeCloseTo(before.k, 5)
+
+    // '+' zooms in (scale increases), '-' zooms out.
+    await page.keyboard.press('+')
+    const afterZoomIn = await getView(page)
+    expect(afterZoomIn.k).toBeGreaterThan(afterPan.k)
+
+    await page.keyboard.press('-')
+    const afterZoomOut = await getView(page)
+    expect(afterZoomOut.k).toBeLessThan(afterZoomIn.k)
+
+    // '0' resets to the identity view.
+    await page.keyboard.press('0')
+    const reset = await getView(page)
+    expect(reset).toEqual({ x: 0, y: 0, k: 1 })
+  })
+
+  test('persona node is focusable and Enter navigates to its page', async ({ page }) => {
+    await page.goto('/')
+    await waitForGraph(page)
+
+    const persona = page.locator('g[role="button"][aria-label^="Persona:"]').first()
+    await persona.focus()
+
+    // Focusing a persona draws a focus ring (a stroked circle inside the node).
+    await expect(persona.locator('circle[stroke][fill="none"]')).toHaveCount(1)
+
+    await page.keyboard.press('Enter')
+    await expect(page).toHaveURL(/\/persona\//)
+  })
+})
+
+test.describe('graph touch interaction', () => {
+  test.use({ hasTouch: true })
+
+  test('first tap pins (highlights), second tap activates', async ({ page }) => {
+    await page.goto('/')
+    await waitForGraph(page)
+
+    const persona = page.locator('g[role="button"][aria-label^="Persona:"]').first()
+    const box = await persona.boundingBox()
+    if (!box) throw new Error('persona node has no bounding box')
+    const cx = box.x + box.width / 2
+    const cy = box.y + box.height / 2
+
+    // First tap: pins the persona, highlighting connected edges — does NOT
+    // navigate (hover does not exist on touch, so tap stands in for it).
+    await page.touchscreen.tap(cx, cy)
+    await expect(page).toHaveURL(/\/$/)
+    // A pinned persona highlights its edges in orange (#f97316).
+    await expect(page.locator('svg line[stroke="#f97316"]').first()).toBeVisible()
+
+    // Second tap on the same node activates it.
+    await page.touchscreen.tap(cx, cy)
+    await expect(page).toHaveURL(/\/persona\//)
+  })
+
+  test('pinch gesture zooms the view in', async ({ page }) => {
+    await page.goto('/')
+    await waitForGraph(page)
+
+    const before = await getView(page)
+
+    // Playwright has no first-class pinch, so dispatch two synthetic touch
+    // pointers and spread them apart. These bubble to React's delegated
+    // pointer listeners exactly like real touch input.
+    await page.evaluate(() => {
+      const svg = document.querySelector('svg[role="application"]') as SVGElement
+      const rect = svg.getBoundingClientRect()
+      const midX = rect.left + rect.width / 2
+      const midY = rect.top + rect.height / 2
+      const fire = (type: string, id: number, x: number, y: number) =>
+        svg.dispatchEvent(
+          new PointerEvent(type, {
+            pointerId: id,
+            pointerType: 'touch',
+            clientX: x,
+            clientY: y,
+            bubbles: true,
+            cancelable: true,
+          })
+        )
+      // Two fingers start 40px apart, end 240px apart -> ~6x finger spread.
+      fire('pointerdown', 1, midX - 20, midY)
+      fire('pointerdown', 2, midX + 20, midY)
+      for (let i = 1; i <= 6; i++) {
+        const off = 20 + i * (100 / 6)
+        fire('pointermove', 1, midX - off, midY)
+        fire('pointermove', 2, midX + off, midY)
+      }
+      fire('pointerup', 1, midX - 120, midY)
+      fire('pointerup', 2, midX + 120, midY)
+    })
+
+    const after = await getView(page)
+    expect(after.k).toBeGreaterThan(before.k)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build:ideas": "node scripts/build-ideas.mjs",
     "dev": "node scripts/build-ideas.mjs && vite",
     "build": "node scripts/build-ideas.mjs && vite build && cp dist/index.html dist/404.html",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@formspree/react": "^3.0.0",
@@ -19,6 +20,7 @@
     "three": "^0.183.2"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@types/node": "^22.14.0",
     "@vitejs/plugin-react": "^5.0.0",
     "js-yaml": "^4.1.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// E2E smoke tests for graph interactions (touch + keyboard). The dev server
+// rebuilds ideas.json then serves on :3000; reuse it if one is already up.
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  retries: process.env.CI ? 1 : 0,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
         specifier: ^0.183.2
         version: 0.183.2
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@types/node':
         specifier: ^22.14.0
         version: 22.19.17
@@ -326,6 +329,11 @@ packages:
     resolution: {integrity: sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==}
     peerDependencies:
       three: '>= 0.159.0'
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@react-three/drei@10.7.7':
     resolution: {integrity: sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==}
@@ -661,6 +669,11 @@ packages:
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -764,6 +777,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.12:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
@@ -1222,6 +1245,10 @@ snapshots:
       promise-worker-transferable: 1.0.4
       three: 0.183.2
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@react-three/drei@10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(three@0.183.2))(@types/react@19.2.14)(@types/three@0.184.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(three@0.183.2)':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -1528,6 +1555,9 @@ snapshots:
 
   fflate@0.8.2: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -1602,6 +1632,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.12:
     dependencies:


### PR DESCRIPTION
## What

The persona↔idea graph was mouse-only and inaccessible by keyboard. This adds full touch and keyboard interaction without changing desktop behavior.

- **Unified Pointer Events** — mouse, touch, and pen now share one code path (replaces the mouse-only handlers).
- **Touch pan + pinch-zoom** — one finger pans; two fingers pinch-zoom toward the gesture midpoint (clamped to the existing 0.5–4× range). `touch-action: none` stops the browser hijacking the gesture.
- **Tap-to-pin** — hover doesn't exist on touch, which made the graph's signature mechanic (highlight a persona's connected ideas) unreachable. First tap now pins/highlights a node; a second tap on the same node activates it. Mouse clicks still activate directly.
- **Keyboard** — arrows pan, `+`/`−` zoom, `0` resets, `Esc` clears. The 18 persona nodes are focusable (`role="button"`, per-node `aria-label`) with a focus ring; Enter/Space opens them. The 107 idea nodes are left to the `/ideas` list to avoid 100+ tab stops.

## Tests

New Playwright suite (`e2e/graph.spec.ts`, run with `pnpm test:e2e`) covering keyboard pan/zoom/reset, persona focus + Enter navigation, touch tap-to-pin (two-stage), and synthetic pinch-zoom. All 4 pass locally. Config reuses a running dev server. No CI wiring added (by request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)